### PR TITLE
Switch windows to Clang

### DIFF
--- a/llama/make/common-defs.make
+++ b/llama/make/common-defs.make
@@ -57,6 +57,10 @@ ifeq ($(OS),windows)
 	EXE_EXT := .exe
 	SHARED_PREFIX := 
 	CPU_FLAG_PREFIX := /arch:
+	_GCC_TEST:=$(findstring clang,$(shell gcc --version))
+	ifneq ($(_GCC_TEST),clang)
+$(error WRONG COMPILER DETECTED $(shell type gcc) - gcc must be a clang compat compiler on windows - see docs/development.md for setup instructions)
+	endif
 ifneq ($(HIP_PATH),)
 	# If HIP_PATH has spaces, hipcc trips over them when subprocessing
 	HIP_PATH := $(shell cygpath -m -s "$(patsubst %\,%,$(HIP_PATH))")


### PR DESCRIPTION
The recent deepseek patch for windows only works if built with clang.

CI changes carried on https://github.com/ollama/ollama/pull/7157 - it doesn't appear the clang installed in the standard github runner windows image has the gcc compat wrapper, so we'll use msys2 to get that installed. While make is already present, I went ahead and replicated the documented instructions for completeness.

      - name: Install msys2
        run: |
          $msys2_url="https://github.com/msys2/msys2-installer/releases/download/2024-07-27/msys2-x86_64-20240727.exe"
          write-host "Downloading msys2"
          Invoke-WebRequest -Uri "${msys2_url}" -OutFile "${env:RUNNER_TEMP}\msys2.exe"
          write-host "Installing msys2"
          Start-Process "${env:RUNNER_TEMP}\msys2.exe" -ArgumentList @("in", "--confirm-command", "--accept-messages", "--root", "C:/msys64") -NoNewWindow -Wait
          echo "c:\msys64\usr\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
      - name: Install msys2 tools
        run: |
          Start-Process "c:\msys64\usr\bin\pacman.exe" -ArgumentList @("-S", "--noconfirm", "mingw-w64-clang-x86_64-gcc-compat", "mingw-w64-clang-x86_64-clang", "make") -NoNewWindow -Wait
          echo "C:\msys64\clang64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
      - name: verify tools
        run: |
          get-command gcc
          gcc --version
          get-command make
          make --version